### PR TITLE
feature: add Trello support

### DIFF
--- a/lib/trello.js
+++ b/lib/trello.js
@@ -1,0 +1,21 @@
+{
+  search:[
+    {
+      type:'link',
+      query:'https://trello.com/1/search?modelTypes=cards&elasticsearch=true&query={{term}}',
+      translate:'parseJSON(response)',
+      name:{
+        selector:'.cards :root',
+        expression:'element.name'
+      },
+      description:{
+        selector:'.cards .desc',
+        expression: 'element'
+      },
+      link:{
+        selector:'.cards .url',
+        expression:'element'
+      }
+    }
+  ]
+}


### PR DESCRIPTION
The `name` part is a little bit weird but when `.cards .name` is provided cards' labels are displayed in some results. Maybe a bug in parser?

**Igor**
