### PR TITLE
Fix image search from imgur

### DIFF
--- a/lib/imgur.js
+++ b/lib/imgur.js
@@ -1,19 +1,45 @@
 {
   search:[
     {
-      query:'http://imgur.com/?q={{term}}',
+      type:'image',
+      query:'http://imgur.com/search/score?q={{term}}',
       translate:'parseHTML(response)',
+      icon:{
+        selector:'.image-list-link img',
+        expression:'element.getAttribute("src")'
+      },
       name:{
-        selector:'.posts .post img',
-        expression:'$(element).attr("title").substr(0, $(element).attr("title").indexOf("<"))'
+        selector:'.hover p',
+        expression:'element.textContent'
       },
       link:{
-        selector:'.posts .post a',
-        expression:'"https://imgur.com" + $(element).attr("href")'
+        selector:'.image-list-link',
+        expression:'"http://imgur.com" + element.getAttribute("href")'
       },
       description:{
-        selector:'.posts .post img',
-        expression:'$($(element).attr("title").substr($(element).attr("title").indexOf("<"))).text()'
+        selector:'.image-list-link',
+        expression:'"http://imgur.com" + element.getAttribute("href")'
+      }
+    },
+    {
+      type:'image',
+      query:'http://imgur.com/search/relevance?q={{term}}',
+      translate:'parseHTML(response)',
+      icon:{
+        selector:'.image-list-link img',
+        expression:'element.getAttribute("src")'
+      },
+      name:{
+        selector:'.hover p',
+        expression:'element.textContent'
+      },
+      link:{
+        selector:'.image-list-link',
+        expression:'"http://imgur.com" + element.getAttribute("href")'
+      },
+      description:{
+        selector:'.image-list-link',
+        expression:'"http://imgur.com" + element.getAttribute("href")'
       }
     }
   ]


### PR DESCRIPTION
Search images from imgur in both "highest scoring" and "most relevant"
sort order.
Closes starthq/search#16.