### PR TITLE
facebook integration - added events search

### DIFF
--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -1,37 +1,52 @@
 {
-	search : [{
-	    type : 'message',
-	    query : 'https://touch.facebook.com/messages/?q={{term}}',
-	    translate : 'parseHTML(response)',
-	    name : {
-	      selector : 'header > h3 > strong',
-	      expression : 'element.textContent'
-	    },
-	    description : {
-	      selector : 'header > h3 > span',
-	      expression : 'element.textContent'
-	    },
-	    link : {
-	      selector : '._5b6s',
-	      expression : '"https://www.facebook.com" + element.getAttribute("href")'
-    	   }
-	  },
-		{
-			type : 'contact',
-			query : 'https://touch.facebook.com/friends/?q={{term}}',
-			translate : 'parseHTML(response)',
-			name : {
-				selector : '.itemWithAction .content > .title > strong',
-				expression : 'element.textContent'
-			},
-      image : {
-				selector : '.itemWithAction > a.touchable.primary',
-				expression : '"https://graph.facebook.com" + element.getAttribute("href").replace("?refid=5","").replace("profile.php?id=","").replace("&refid=5","") + "/picture?type=square&width=100&height=100 "'
-      },
-			link : {
-				selector : '.itemWithAction > a.touchable.primary',
-				expression : '"https://www.facebook.com" + element.getAttribute("href")'
-			}
-		}
-	]
+    search : [
+        {
+            type: 'message',
+            query: 'https://touch.facebook.com/messages/?q={{term}}',
+            translate: 'parseHTML(response)',
+            name: {
+                selector: 'header > h3 > strong',
+                expression: 'element.textContent'
+            },
+            description: {
+                selector: 'header > h3 > span',
+                expression: 'element.textContent'
+            },
+            link: {
+                selector: '._5b6s',
+                expression: '"https://www.facebook.com" + element.getAttribute("href")'
+            }
+        },
+        {
+            type: 'contact',
+            query: 'https://touch.facebook.com/friends/?q={{term}}',
+            translate: 'parseHTML(response)',
+            name: {
+                selector: '.itemWithAction .content > .title > strong',
+                expression: 'element.textContent'
+            },
+            image: {
+                selector: '.itemWithAction > a.touchable.primary',
+                expression: '"https://graph.facebook.com" + element.getAttribute("href").replace("?refid=5","").replace("profile.php?id=","").replace("&refid=5","") + "/picture?type=square&width=100&height=100 "'
+            },
+            link: {
+                selector: '.itemWithAction > a.touchable.primary',
+                expression: '"https://www.facebook.com" + element.getAttribute("href")'
+            }
+        },
+        {
+            type: 'event',
+            query: 'https://touch.facebook.com/search/?search=event&query={{term}}',
+            translate: 'parseHTML(response)',
+            name: {
+                selector: '#objects_container .item .content > .title > strong',
+                expression: 'element.textContent'
+            },
+            link: {
+                selector: '#objects_container .item .touchable.primary',
+                expression: '"https://www.facebook.com" + element.getAttribute("href").replace("https://touch.facebook.com","")'
+            }
+
+        }
+    ]
 }


### PR DESCRIPTION
I implemented events search for facebook integration. 
Search is global and is performed for all the events.

I also tried to implement search among events current user participates or organizes, but the same approach like with messages search didn't work. Requests https://touch.facebook.com/events/?q={{term}} contain all the user's events.

I had a problem when trying to show a picture of the event. Link to a picture is located in style attribute of an element, and I came up with this solution, but unfortunately didn't work:

```
image : {
				selector : '#objects_container .item .touchable.primary .img',
				expression : 'element.getAttribute("style").substr(element.getAttribute("style").indexOf("url(")+5,element.getAttribute("style").substr(element.getAttribute("style").indexOf("url(")+5).indexOf("\""))'
}
```
particularly .indexOf("\"") - It seemed that escaping backslash was removed from the expression. Using &#34; instead of " didn't work also. 